### PR TITLE
Fix to handle relative path in Valgrind XML output

### DIFF
--- a/ValgrindCI/parse.py
+++ b/ValgrindCI/parse.py
@@ -62,7 +62,7 @@ class Error:
     def find_first_source_reference(self, source_dir):
         for i, frame in enumerate(self.stack):
             filename = frame.get_path(None)
-            if filename is not None:
+            if filename is not None and os.path.isabs(filename):
                 if (
                     source_dir is None
                     or os.path.commonpath([source_dir, filename]) == source_dir


### PR DESCRIPTION
Under Ubuntu 22.04, Valgrind can output relative path to the XML output, e.g.
- ./string/../include
- ./elf/./elf
- ./dlfcn/./dlfcn
- etc.
This results in an exception in parse.py in function "find_first_source_reference".