### PR TITLE
Fix to only add Frame with an 'obj'

### DIFF
--- a/ValgrindCI/parse.py
+++ b/ValgrindCI/parse.py
@@ -41,13 +41,15 @@ class Error:
         self.kind = tag.find("kind").text
         self.unique = int(tag.find("unique").text, 16)
         for frame in tag.find("stack").findall("frame"):
-            self.stack.append(Frame(frame))
+            if frame.find("obj") is not None:
+                self.stack.append(Frame(frame))
         self.auxstack = []
         self.auxwhat = tag.find("auxwhat")
         if self.auxwhat is not None:
             self.auxwhat = self.auxwhat.text
             for frame in tag.find("./stack[2]").findall("frame"):
-                self.auxstack.append(Frame(frame))
+                if frame.find("obj") is not None:
+                    self.auxstack.append(Frame(frame))
 
     def __str__(self):
         s = f"{self.what} (0x{self.unique:x})"


### PR DESCRIPTION
For some interesting reasons, there are Frames with an 'obj'. If added, an exception is thrown in the first line of Frame __init__:
```python
class Frame:
    def __init__(self, tag):
        self.obj = tag.find("obj").text
```
So I added a test to make sure that only Frames with an 'obj' are considered.