### PR TITLE
Multiple features: source path substitution, relative source filename display, custom HTML report title

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ ValgrindCI uses the `setuptools` to build its package which can then be installe
 > pip install ValgrindCI --no-index -f dist
 ```
 
+#### Build and package an executable with `pyinstaller`
+
+You can use `pyinstaller` to create a single-file executable binary:
+
+```bash
+> pip install pyinstaller
+> pyinstaller --onefile --add-data ValgrindCI:ValgrindCI valgrind-ci
+> ./dist/valgrind-ci --help
+```
+
 ## How to use
 
 ValgrindCI is a command tool designed to be executed within jobs of your favorite Continuous Integration platform. It parses the XML output of valgrind to provide its services.

--- a/ValgrindCI/__init__.py
+++ b/ValgrindCI/__init__.py
@@ -38,6 +38,11 @@ def main():
         "--output-dir", help="directory where the HTML report will be generated"
     )
     parser.add_argument(
+        "--html-report-title",
+        default="ValgrindCI Report",
+        help="the title of the generated HTML report"
+    )
+    parser.add_argument(
         "--summary",
         default=False,
         action="store_true",
@@ -102,7 +107,7 @@ def main():
     if args.output_dir:
         renderer = HTMLRenderer(data)
         renderer.set_source_dir(args.source_dir)
-        renderer.render(args.output_dir, args.lines_before, args.lines_after)
+        renderer.render(args.html_report_title, args.output_dir, args.lines_before, args.lines_after)
 
     if args.number_of_errors:
         print("{} errors.".format(errors_total))

--- a/ValgrindCI/__init__.py
+++ b/ValgrindCI/__init__.py
@@ -17,6 +17,12 @@ def main():
         help="specifies the source directory",
     )
     parser.add_argument(
+        "--substitute-path",
+        action="append",
+        help="specifies a substitution rule `from:to` for finding source files on disk. example: --substitute-path /foo:/bar",
+        nargs='?'
+    )
+    parser.add_argument(
         "--output-dir", help="directory where the HTML report will be generated"
     )
     parser.add_argument(
@@ -54,6 +60,12 @@ def main():
     data = ValgrindData()
     data.parse(args.xml_file)
     data.set_source_dir(args.source_dir)
+
+    if args.substitute_path:
+        substitute_paths = []
+        for s in args.substitute_path:
+            substitute_paths.append({"from": s.split(":")[0], "to": s.split(":")[1] })
+        data.set_substitute_paths(substitute_paths)
 
     errors_total = data.get_num_errors()
     if args.abort_on_errors and errors_total != 0:

--- a/ValgrindCI/__init__.py
+++ b/ValgrindCI/__init__.py
@@ -23,6 +23,18 @@ def main():
         nargs='?'
     )
     parser.add_argument(
+        "--relativize",
+        action="append",
+        help="specifies a prefix to remove from displayed source filenames. example: --relativize /foo/bar",
+        nargs='?'
+    )
+    parser.add_argument(
+        "--relativize-from-substitute-paths",
+        default=False,
+        action="store_true",
+        help="use the `from` values in the substitution rules as prefixes to remove from displayed source filenames",
+    )
+    parser.add_argument(
         "--output-dir", help="directory where the HTML report will be generated"
     )
     parser.add_argument(
@@ -66,6 +78,21 @@ def main():
         for s in args.substitute_path:
             substitute_paths.append({"from": s.split(":")[0], "to": s.split(":")[1] })
         data.set_substitute_paths(substitute_paths)
+
+    if args.relativize:
+        prefixes = []
+        for p in args.relativize:
+            prefixes.append(p)
+        data.set_relative_prefixes(prefixes)
+
+    if args.relativize_from_substitute_paths:
+        if not args.substitute_path:
+            print("No substitution paths specified on the command line.")
+        else:
+            prefixes = data._relative_prefixes.copy()
+            for s in data._substitute_paths:
+                prefixes.append(s.get("from"))
+            data.set_relative_prefixes(prefixes)
 
     errors_total = data.get_num_errors()
     if args.abort_on_errors and errors_total != 0:

--- a/ValgrindCI/data/index.html
+++ b/ValgrindCI/data/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <title>Valgrind report</title>
+    <title>{{ title }}</title>
     <link href='valgrind.css' rel='stylesheet' type='text/css'>
 </head>
 
 <body>
     <div class="global">
         <div class="header">
-            <h1>ValgrindCI Report</h1>
+            <h1>{{ title }}</h1>
             <p><b>{{ num_errors }}</b> errors</p>
         </div>
         <table>

--- a/ValgrindCI/parse.py
+++ b/ValgrindCI/parse.py
@@ -118,6 +118,7 @@ class ValgrindData:
     def __init__(self) -> None:
         self.errors: List[Error] = []
         self._source_dir: Optional[str] = None
+        self._substitute_paths: Optional[List[dict]] = []
 
     def parse(self, xml_file: str) -> None:
         root = et.parse(xml_file).getroot()
@@ -129,6 +130,15 @@ class ValgrindData:
             self._source_dir = os.path.abspath(source_dir)
         else:
             self._source_dir = None
+
+    def set_substitute_paths(self, substitute_paths: Optional[List[dict]]) -> None:
+        if substitute_paths is not None:
+            self._substitute_paths = substitute_paths
+
+    def substitute_path(self, path: str) -> str:
+        for s in self._substitute_paths:
+            path = path.replace(s.get("from"), s.get("to"))
+        return path
 
     def get_num_errors(self) -> int:
         if self._source_dir is None:

--- a/ValgrindCI/parse.py
+++ b/ValgrindCI/parse.py
@@ -119,6 +119,7 @@ class ValgrindData:
         self.errors: List[Error] = []
         self._source_dir: Optional[str] = None
         self._substitute_paths: Optional[List[dict]] = []
+        self._relative_prefixes: Optional[List[str]] = []
 
     def parse(self, xml_file: str) -> None:
         root = et.parse(xml_file).getroot()
@@ -135,9 +136,21 @@ class ValgrindData:
         if substitute_paths is not None:
             self._substitute_paths = substitute_paths
 
+    def set_relative_prefixes(self, relative_prefixes: Optional[str]) -> None:
+        if relative_prefixes is not None:
+            self._relative_prefixes = relative_prefixes
+
     def substitute_path(self, path: str) -> str:
         for s in self._substitute_paths:
             path = path.replace(s.get("from"), s.get("to"))
+        return path
+
+    def relativize(self, path: str) -> str:
+        for p in self._relative_prefixes:
+            if path.startswith(p):
+                path = path.replace(p, "")
+                if path.startswith("/"):
+                    path = path[1:]
         return path
 
     def get_num_errors(self) -> int:

--- a/ValgrindCI/render.py
+++ b/ValgrindCI/render.py
@@ -71,14 +71,14 @@ class HTMLRenderer:
                 f.write(
                     self._source_tmpl.render(
                         num_errors=num_errors,
-                        source_file_name=source_file,
+                        source_file_name=self._data.relativize(source_file),
                         codelines=lines_of_code,
                     )
                 )
 
             summary.append(
                 {
-                    "filename": source_file,
+                    "filename": self._data.relativize(source_file),
                     "errors": num_errors,
                     "link": html_filename,
                 }
@@ -121,9 +121,9 @@ class HTMLRenderer:
                 assert error_line is not None
                 stack["line"] = error_line - lines_before - 1
                 stack["error_line"] = lines_before + 1
-                stack["fileref"] = "{}:{}".format(
-                    frame.get_path(self._source_dir), error_line
-                )
+                frame_source = frame.get_path(self._source_dir)
+                frame_source = self._data.relativize(frame_source)
+                stack["fileref"] = "{}:{}".format(frame_source, error_line)
                 fullname = self._data.substitute_path(fullname)
                 try:
                     with open(fullname, "r", errors="replace") as f:

--- a/ValgrindCI/render.py
+++ b/ValgrindCI/render.py
@@ -44,7 +44,7 @@ class HTMLRenderer:
         else:
             self._source_dir = None
 
-    def render(self, output_dir: str, lines_before: int, lines_after: int) -> None:
+    def render(self, report_title: str, output_dir: str, lines_before: int, lines_after: int) -> None:
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         shutil.copy(
@@ -88,7 +88,9 @@ class HTMLRenderer:
         with open(os.path.join(output_dir, "index.html"), "w") as f:
             f.write(
                 self._index_tmpl.render(
-                    source_list=summary, num_errors=total_num_errors
+                    title=report_title,
+                    source_list=summary,
+                    num_errors=total_num_errors
                 )
             )
 


### PR DESCRIPTION
Hello,
I would like to contribute the below features:
- source path substitution
    * The source files used to build the application will not always be in the expected location.
    * This is the same feature as the gdb substitution path to locate source files on disk.
- relative source filename display
    * The full path of the source files can be long and meaningless (see above).
    * This feature allows to display only relative paths, removing a list of prefixes.
- custom HTML report title
    * Self explanatory, ability to change the title of the HTML report from the default "ValgrindCI report"